### PR TITLE
Make `/embed/` links work properly

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -22,5 +22,21 @@ location __PATH__/ {
 }
 
 location __PATH__/embed/ {
+  # Force usage of https
+  if ($scheme = http) {
+    rewrite ^ https://$server_name$request_uri? permanent;
+  }
+
+  proxy_pass        http://127.0.0.1:3000/embed/;
+  proxy_redirect    off;
+  proxy_set_header  Host $host;
+  proxy_set_header  X-Real-IP $remote_addr;
+  proxy_set_header  X-Forwarded-Proto $scheme;
+  proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header  X-Forwarded-Host $server_name;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+
   more_set_headers "X-Frame-Options : ALLOWALL";
 }


### PR DESCRIPTION
Gives them the right headers and redirects them to the right place

## Problem
- To fix #3 
## Solution
- Duplicating the contents of the location block for the bare path in the location block for the `/embed/` path

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/invidious_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/invidious_ynh%20PR-NUM-%20(USERNAME)/)  
