### PR TITLE
Fix external Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Alternative front-end to YouTube
 
-**Shipped version:** 0.20.1~ynh11
+**Shipped version:** 28.07.21~ynh1
 
 **Demo:** https://invidious.site/
 
@@ -29,7 +29,7 @@ Alternative front-end to YouTube
 
 ## Configuration
 
-You can configure Invidious by modifying the configuration file `/var/www/invidious/config/config.yml` with the help of this [documentation](https://github.com/iv-org/documentation/blob/master/Configuration.md).
+You can configure Invidious by modifying the configuration file `/var/www/invidious/config/config.yml` with the help of this [documentation](https://docs.invidious.io/Configuration.md).
 
 ## Limitations
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Front-end alternatif à YouTube
 
-**Version incluse :** 0.20.1~ynh11
+**Version incluse :** 28.07.21~ynh1
 
 **Démo :** https://invidious.site/
 
@@ -25,7 +25,7 @@ Front-end alternatif à YouTube
 
 ## Configuration
 
-Vous pouvez configurer Invidious en modifiant le fichier de configuration `/var/www/invidious/config/config.yaml` avec l'aide de cette [documentation](https://github.com/iv-org/documentation/blob/master/Configuration.md).
+Vous pouvez configurer Invidious en modifiant le fichier de configuration `/var/www/invidious/config/config.yaml` avec l'aide de cette [documentation](https://docs.invidious.io/Configuration.md).
 
 ## Limitations
 

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -76,7 +76,7 @@ port: __PORT__
 ## Accepted values: 1-65535
 ## Default: <none>
 ##
-external_port: __PORT__
+external_port: 80
 
 ##
 ## Interface address to listen on for incoming connections.

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,6 +1,6 @@
 ## Configuration
 
-You can configure Invidious by modifying the configuration file `/var/www/invidious/config/config.yml` with the help of this [documentation](https://github.com/iv-org/documentation/blob/master/Configuration.md).
+You can configure Invidious by modifying the configuration file `/var/www/invidious/config/config.yml` with the help of this [documentation](https://docs.invidious.io/Configuration.md).
 
 ## Limitations
 

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -1,6 +1,6 @@
 ## Configuration
 
-Vous pouvez configurer Invidious en modifiant le fichier de configuration `/var/www/invidious/config/config.yaml` avec l'aide de cette [documentation](https://github.com/iv-org/documentation/blob/master/Configuration.md).
+Vous pouvez configurer Invidious en modifiant le fichier de configuration `/var/www/invidious/config/config.yaml` avec l'aide de cette [documentation](https://docs.invidious.io/Configuration.md).
 
 ## Limitations
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Alternative front-end to YouTube",
         "fr": "Front-end alternatif à YouTube"
     },
-    "version": "0.20.1~ynh11",
+    "version": "28.07.21~ynh1",
     "url": "https://invidio.us/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,6 +4,8 @@
 # COMMON VARIABLES
 #=================================================
 
+version_commit=5c76cdaad9da2330311e78fc4e451c40e88a9598
+
 # dependencies used by the app
 pkg_dependencies="apt-transport-https libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin libsqlite3-dev zlib1g-dev libevent-dev pkg-config libpcre3-dev"
 

--- a/scripts/install
+++ b/scripts/install
@@ -101,6 +101,10 @@ ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 # Download, check integrity, uncompress and patch the source from GitHub
 git clone https://github.com/iv-org/invidious "$final_path" --quiet
 
+pushd "$final_path"
+	git reset --hard --quiet $version_commit
+popd
+
 for i in $final_path/config/sql/*.sql ; do
 	ynh_replace_string --match_string="kemal" --replace_string=$db_user --target_file="$i" ;
 	ynh_psql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < "$i" ;

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -99,12 +99,11 @@ then
 	# Backup the config file in the temp dir
 	#cp -a "$final_path/config/config.yml" "$tmpdir/config.yml"
 
-	# Remove the app directory securely
-	#ynh_secure_remove --file=$final_path
-
-	#git clone https://github.com/iv-org/invidious "$final_path" --quiet
 	pushd $final_path
+		git fetch
+      	#git checkout master
 		git pull
+		git reset --hard --quiet $version_commit
 		shards update && shards install
 		crystal build $final_path/src/invidious.cr --release
 	popd


### PR DESCRIPTION
External Port should be 80, as it would result in RSS Feeds with the Port 3001 otherwise.

## Problem

- *Articles in the RSS-Feed had the Port 3001, which wasn't able to be opened.*

## Solution

- *Now it's 80. The Feeds do not include any Port, as it is the default Port for Websites.*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)work you need to be a member of the Yunohost-Apps organization)