### PR TITLE
config.yml may not exist during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -118,7 +118,6 @@ fi
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
-chmod 600 $final_path/config/config.yml
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
## Problem

- An user had an upgrade crash because config.yml doesnt exists during the chown ...

## Solution

The config.yml is re-configured and chmod later in the script, no need to do the chown at that time

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
