### PR TITLE
compile without liblsquic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition to constituting an advantage in terms of confidentiality (the data d
 - Ability to subscribe to channels without creating a Google account 
 
 
-**Shipped version:** 22.07.14~ynh1
+**Shipped version:** 22.08.05~ynh1
 
 **Demo:** https://invidious.site/
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition to constituting an advantage in terms of confidentiality (the data d
 - Ability to subscribe to channels without creating a Google account 
 
 
-**Shipped version:** 22.08.12~ynh1
+**Shipped version:** 22.08.14~ynh1
 
 
 **Demo:** https://invidious.site/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition to constituting an advantage in terms of confidentiality (the data d
 - Ability to subscribe to channels without creating a Google account 
 
 
-**Shipped version:** 22.06.15~ynh1
+**Shipped version:** 22.07.14~ynh1
 
 **Demo:** https://invidious.site/
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ In addition to constituting an advantage in terms of confidentiality (the data d
 - Ability to subscribe to channels without creating a Google account 
 
 
-**Shipped version:** 22.08.05~ynh1
+**Shipped version:** 22.08.12~ynh1
+
 
 **Demo:** https://invidious.site/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ En plus de constituer un avantage sur le plan de la confidentialité (les donné
 - Possibilité d'afficher les commentaires Reddit plutôt que les commentaires YouTube,
 - Possibilité de s'abonner aux chaines sans créer de compte Google
 
-**Version incluse :** 22.06.15~ynh1
+**Version incluse :** 22.07.14~ynh1
 
 **Démo :** https://invidious.site/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,8 @@ En plus de constituer un avantage sur le plan de la confidentialité (les donné
 - Possibilité d'afficher les commentaires Reddit plutôt que les commentaires YouTube,
 - Possibilité de s'abonner aux chaines sans créer de compte Google
 
-**Version incluse :** 22.08.05~ynh1
+**Version incluse :** 22.08.12~ynh1
+
 
 **Démo :** https://invidious.site/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ En plus de constituer un avantage sur le plan de la confidentialité (les donné
 - Possibilité d'afficher les commentaires Reddit plutôt que les commentaires YouTube,
 - Possibilité de s'abonner aux chaines sans créer de compte Google
 
-**Version incluse :** 22.07.14~ynh1
+**Version incluse :** 22.08.05~ynh1
 
 **Démo :** https://invidious.site/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ En plus de constituer un avantage sur le plan de la confidentialité (les donné
 - Possibilité d'afficher les commentaires Reddit plutôt que les commentaires YouTube,
 - Possibilité de s'abonner aux chaines sans créer de compte Google
 
-**Version incluse :** 22.08.12~ynh1
+**Version incluse :** 22.08.14~ynh1
 
 
 **Démo :** https://invidious.site/

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Alternative front-end to YouTube",
         "fr": "Front-end alternatif à YouTube"
     },
-    "version": "22.06.15~ynh1",
+    "version": "22.07.14~ynh1",
     "url": "https://invidio.us/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Alternative front-end to YouTube",
         "fr": "Front-end alternatif à YouTube"
     },
-    "version": "22.08.12~ynh1",
+    "version": "22.08.14~ynh1",
     "url": "https://invidio.us/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Alternative front-end to YouTube",
         "fr": "Front-end alternatif à YouTube"
     },
-    "version": "22.07.14~ynh1",
+    "version": "22.08.05~ynh1",
     "url": "https://invidio.us/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Alternative front-end to YouTube",
         "fr": "Front-end alternatif à YouTube"
     },
-    "version": "22.08.05~ynh1",
+    "version": "22.08.12~ynh1",
     "url": "https://invidio.us/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-version_commit=6577cc0c8c08e563065ee11ff39c1aad76f16878
+version_commit=4ab54f284c8585f2edec44a4b0d369813389e142
 
 # dependencies used by the app
 pkg_dependencies="apt-transport-https libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin imagemagick libsqlite3-dev zlib1g-dev libevent-dev pkg-config libpcre3-dev"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-version_commit=4ab54f284c8585f2edec44a4b0d369813389e142
+version_commit=9cc041876944dde46cd8cc3e269995244c8e7724
 
 # dependencies used by the app
 pkg_dependencies="apt-transport-https libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin imagemagick libsqlite3-dev zlib1g-dev libevent-dev pkg-config libpcre3-dev"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-version_commit=6c73614a47a5a88df45aa32fadb64e85595d2a18
+version_commit=6577cc0c8c08e563065ee11ff39c1aad76f16878
 
 # dependencies used by the app
 pkg_dependencies="apt-transport-https libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin imagemagick libsqlite3-dev zlib1g-dev libevent-dev pkg-config libpcre3-dev"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-version_commit=9cc041876944dde46cd8cc3e269995244c8e7724
+version_commit=9e58bc19c4baf7ca7da97c2f8b164789d041d9b8
 
 # dependencies used by the app
 pkg_dependencies="apt-transport-https libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin imagemagick libsqlite3-dev zlib1g-dev libevent-dev pkg-config libpcre3-dev"

--- a/scripts/install
+++ b/scripts/install
@@ -140,7 +140,7 @@ ynh_script_progression --message="Building Invidious.. (this will take some time
 
 pushd "$final_path"
 	ynh_exec_warn_less shards install --production
-	ynh_exec_warn_less crystal build $final_path/src/invidious.cr --release
+	ynh_exec_warn_less crystal build -Ddisable_quic $final_path/src/invidious.cr --release
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- As reported in issue #95, the build fails. This PR disables compilation with quic. However, this is not conditional on the architecture and this PR could be optimised to disable quic only on arm64 devices.

## Solution

- compile with crystal -Ddisable_quic, it works. test at yt.fg3.eu

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
