### PR TITLE
Use resources.sources instead of git

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -84,7 +84,7 @@ external_port: 443
 ## Accepted values: a valid IPv4 or IPv6 address.
 ## default: 0.0.0.0  (listen on all interfaces)
 ##
-host_binding: 0.0.0.0
+host_binding: 127.0.0.1
 
 ##
 ## Domain name under which this instance is hosted. This is

--- a/manifest.toml
+++ b/manifest.toml
@@ -48,6 +48,12 @@ ram.runtime = "50M"
     default = "fr"
 
 [resources]
+    [resources.sources]
+        [resources.sources.main]
+        url = "https://github.com/iv-org/invidious/archive/d956b1826e15da6cfcd9a1531b0f1e6ef577dd10.tar.gz"
+        sha256 = "d5478d5c9e473998594c58eafa01c74dcfa9bdf3eebea4250afa1443c47481c1"
+        autoupdate.strategy = "latest_github_commit"
+
     [resources.system_user]
 
     [resources.install_dir]

--- a/manifest.toml
+++ b/manifest.toml
@@ -43,7 +43,7 @@ ram.runtime = "50M"
     [install.language]
     ask.en = "Choose the application language"
     ask.fr = "Choisissez la langue de l'application"
-    type = "string"
+    type = "select"
     choices = ["de", "en-US", "es", "fr", "it", "nl", "pt-PT"]
     default = "fr"
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -19,6 +19,15 @@ ynh_script_progression --message="Stopping a systemd service..." --weight=1
 ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd"
 
 #=================================================
+# MODIFY A CONFIG FILE
+#=================================================
+ynh_script_progression --message="Modifying a config file..."
+
+ynh_add_config --template="../conf/config.yml" --destination="$install_dir/config/config.yml"
+chmod 600 $install_dir/config/config.yml
+chown $app:$app "$install_dir/config/config.yml"
+
+#=================================================
 # MODIFY URL IN NGINX CONF
 #=================================================
 ynh_script_progression --message="Updating NGINX web server configuration..." --weight=2

--- a/scripts/install
+++ b/scripts/install
@@ -40,20 +40,8 @@ ynh_exec_warn_less curl -fsSL https://crystal-lang.org/install.sh | bash -s -- -
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=4
 
-mkdir -p "$install_dir"
-chown -R $app:www-data "$install_dir"
+ynh_setup_source --dest_dir="$install_dir"
 
-git config --system --add safe.directory $install_dir
-
-# Download, check integrity, uncompress and patch the source from GitHub
-git clone https://github.com/iv-org/invidious "$install_dir" --quiet
-
-pushd "$install_dir"
-	git reset --hard --quiet $version_commit
-	make
-popd
-
-chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -42,6 +42,10 @@ ynh_script_progression --message="Setting up source files..." --weight=4
 
 ynh_setup_source --dest_dir="$install_dir"
 
+pushd "$install_dir"
+	make
+popd
+
 chown -R $app:www-data "$install_dir"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -65,6 +65,10 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=5
 
 	ynh_setup_source --dest_dir="$install_dir" --full_replace=1
+
+	pushd "$install_dir"
+		make
+	popd
 fi
 
 chown -R $app:www-data "$install_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -64,20 +64,9 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=5
 
-	pushd $install_dir
-		chown -R $app:www-data "$install_dir"
-		git config --system --add safe.directory $install_dir
-		
-		ynh_exec_as $app git fetch
-    	#git checkout master
-    	ynh_exec_as $app git reset --hard --quiet $version_commit
-		ynh_exec_as $app git pull
-		ynh_exec_warn_less shards install --production
-		ynh_exec_warn_less crystal build $install_dir/src/invidious.cr --release
-	popd
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1
 fi
 
-chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
@@ -105,6 +94,7 @@ ynh_script_progression --message="Modifying a config file..."
 
 ynh_add_config --template="../conf/config.yml" --destination="$install_dir/config/config.yml"
 chmod 600 $install_dir/config/config.yml
+chown $app:$app "$install_dir/config/config.yml"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
- Use resources.sources instead of git
- Bind on 127.0.0.1 insteaf of 0.0.0.0
- Regen invidious config during change_url

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
