### PR TITLE
Only build invidious once per install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition to constituting an advantage in terms of confidentiality (the data d
 - Ability to subscribe to channels without creating a Google account 
 
 
-**Shipped version:** 23.08.02~ynh1
+**Shipped version:** 23.08.26~ynh1
 
 **Demo:** https://invidious.site/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -26,7 +26,7 @@ En plus de constituer un avantage sur le plan de la confidentialité (les donné
 - Possibilité d'afficher les commentaires Reddit plutôt que les commentaires YouTube,
 - Possibilité de s'abonner aux chaines sans créer de compte Google
 
-**Version incluse :** 23.08.02~ynh1
+**Version incluse :** 23.08.26~ynh1
 
 **Démo :** https://invidious.site/
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Invidious"
 description.en = "Alternative front-end to YouTube"
 description.fr = "Front-end alternatif à YouTube"
 
-version = "23.08.02~ynh1"
+version = "23.08.26~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -60,6 +60,10 @@ ram.runtime = "50M"
     api.show_tile = false
     api.allowed = ["visitors"]
     api.protected = true
+    vi.url = "/vi"
+    vi.show_tile = false
+    vi.allowed = ["visitors"]
+    vi.protected = true
 
     [resources.apt]
     packages = "libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev postgresql librsvg2-bin imagemagick libsqlite3-dev zlib1g-dev libevent-dev libpcre3-dev"

--- a/manifest.toml
+++ b/manifest.toml
@@ -29,7 +29,6 @@ ram.runtime = "50M"
 [install]
     [install.domain]
     type = "domain"
-    full_domain = true
 
     [install.admin]
     type = "user"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-version_commit=d956b1826e15da6cfcd9a1531b0f1e6ef577dd10
+version_commit=34508966027fce3f460d9670eeecef67b92565a0
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -75,9 +75,6 @@ ynh_script_progression --message="Building Invidious.. (this will take some time
 
 pushd "$install_dir"
 	./invidious --migrate
-	ynh_exec_warn_less shards install --production
-	ynh_exec_warn_less crystal build $install_dir/src/invidious.cr --release
-	#ynh_exec_warn_less crystal build $install_dir/src/invidious.cr --Ddisable_quic --release
 popd
 
 #=================================================


### PR DESCRIPTION
`make` in install script already builds invidious... which is why we can use `invidious --migrate`. We don't need to build it a second time.