### PR TITLE
pull strategy

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -77,6 +77,7 @@ then
 	pushd "$install_dir"
 		chown -R "$app:www-data" "$install_dir"
 		git config --system --add safe.directory "$install_dir"
+		git config pull.rebase false
 		
 		ynh_exec_as "$app" git fetch
     	#git checkout master

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -77,7 +77,7 @@ then
 	pushd "$install_dir"
 		chown -R "$app:www-data" "$install_dir"
 		git config --system --add safe.directory "$install_dir"
-		git config pull.rebase false
+		ynh_exec_as "$app" git config pull.rebase false
 		
 		ynh_exec_as "$app" git fetch
     	#git checkout master


### PR DESCRIPTION
## Problem

- git complains about choosing a pull strategy at each source upgrade

```test
12781 WARNING hint: Pulling without specifying how to reconcile divergent branches is
12782 WARNING hint: discouraged. You can squelch this message by running one of the following
12782 WARNING hint: commands sometime before your next pull:
12783 WARNING hint:
12783 WARNING hint:   git config pull.rebase false  # merge (the default strategy)
12783 WARNING hint:   git config pull.rebase true   # rebase
12784 WARNING hint:   git config pull.ff only       # fast-forward only
12784 WARNING hint:
12784 WARNING hint: You can replace "git config" with "git config --global" to set a default
12785 WARNING hint: preference for all repositories. You can also pass --rebase, --no-rebase,
12785 WARNING hint: or --ff-only on the command line to override the configured default per
12786 WARNING hint: invocation.
```

## Solution

- [choose a pull strategy](https://github.com/YunoHost-Apps/invidious_ynh/pull/151/commits/78f22bffb3f59d474efd10b9229e4d30505803e7)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)